### PR TITLE
fix: upgrade to Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
-node_js:
-  - 8.9.3
-cache:
-  directories:
-    - "~/.npm"
+node_js: 12
 before_script:
   - npm i -g gatsby
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copied from https://github.com/BretFisher/node-docker-good-defaults/blob/master/Dockerfile
 
-FROM node:8.9.3
+FROM node:12
 
 # Create app directory
 RUN mkdir -p /edx/app


### PR DESCRIPTION
As part of the upgrade efforts to Node 12, this PR updates this repo from Node 8 to 12. Once this PR lands, we can update the column for this repo with a 🍑 😄- https://openedx.atlassian.net/wiki/spaces/FEDX/pages/931561855/Frontend+Repos.