### PR TITLE
Fix Google fonts import

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,6 +35,16 @@ module.exports = {
       },
     },
     {
+      resolve: 'gatsby-plugin-google-fonts',
+      options: {
+        fonts: [
+          'Inter:400,500,700',
+          'Roboto Mono',
+        ],
+        display: 'swap',
+      },
+    },
+    {
       resolve: 'gatsby-plugin-env-variables',
       options: {
         whitelist: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -8066,6 +8066,11 @@
       "resolved": "https://registry.npmjs.org/gatsby-plugin-env-variables/-/gatsby-plugin-env-variables-1.0.1.tgz",
       "integrity": "sha512-TnXU+IjvM3iHcaNOa+alqP3Wk19+pmxvXwMyoPaUZIDKNwvpXRz8klsag2AwNlsqD17949/m8I80z8plZRyE1w=="
     },
+    "gatsby-plugin-google-fonts": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-fonts/-/gatsby-plugin-google-fonts-1.0.1.tgz",
+      "integrity": "sha512-p1NVkn27GUnDA5qHM+Z4cCcLCJIardzZXMon3640sT4xuL/AZJbsx3HEt2KY/5oZu0UXIkytkxzV2Da4rQeUIg=="
+    },
     "gatsby-plugin-page-creator": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.17.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "font-awesome": "^4.7.0",
     "gatsby": "^2.1.31",
     "gatsby-plugin-env-variables": "^1.0.1",
+    "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-react-helmet": "^3.1.0",
     "gatsby-plugin-sass": "^2.0.11",
     "history": "^4.7.2",

--- a/src/components/program/hero/styles/Hero.scss
+++ b/src/components/program/hero/styles/Hero.scss
@@ -1,4 +1,3 @@
-@import "~@edx/brand/paragon/fonts";
 @import "~@edx/brand/paragon/variables";
 @import "~@edx/paragon/scss/core/core";
 @import "~@edx/brand/paragon/overrides";

--- a/src/components/program/styles/ProgramPage.scss
+++ b/src/components/program/styles/ProgramPage.scss
@@ -1,4 +1,3 @@
-@import "~@edx/brand/paragon/fonts";
 @import "~@edx/brand/paragon/variables";
 @import "~@edx/paragon/scss/core/core";
 @import "~@edx/brand/paragon/overrides";


### PR DESCRIPTION
Fixing compilation issue with Gatsby by moving the font imports to a plugin; may need to update https://github.com/edx/frontend-learner-portal-base if the problem persists.