### PR TITLE
Fix menu and document dropdown buttons

### DIFF
--- a/src/components/program/sidebar/Links.jsx
+++ b/src/components/program/sidebar/Links.jsx
@@ -56,7 +56,7 @@ class Links extends Component {
         </nav>
         {links.length > defaultNumLinksDisplayed && (
           <Button
-            buttonType="link"
+            variant="link"
             className="toggle-show-all-btn px-0"
             onClick={this.handleToggleExpandedClick}
             aria-controls={id}

--- a/src/components/program/styles/ProgramPage.scss
+++ b/src/components/program/styles/ProgramPage.scss
@@ -2,6 +2,11 @@
 @import "@edx/paragon/scss/core/core";
 @import "@edx/brand/paragon/overrides";
 
+// temporary override
+div.menu button.menu-trigger {
+  @extend .btn-outline-primary;
+}
+
 .course-section {
   @extend .mb-5;
 

--- a/src/components/programs-list/styles/ProgramListPage.scss
+++ b/src/components/programs-list/styles/ProgramListPage.scss
@@ -2,6 +2,11 @@
 @import "@edx/paragon/scss/core/core";
 @import "@edx/brand/paragon/overrides";
 
+// temporary override
+div.menu button.menu-trigger {
+  @extend .btn-outline-primary;
+}
+
 .title-override {
   font-family: 'Inter';
   font-weight: 700;


### PR DESCRIPTION
Override for the menu dropdown in the header, as well as a fix to the document dropdown which was displaying as btn-primary rather than btn-link.