### PR TITLE
update openedx.yaml to use current best practices

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,11 +1,6 @@
 # This file describes this Open edX repo, as described in OEP-2:
 # https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html#specification
 
-nick: frontend-app-learner
-owner:
-  type: team
-  team: masters-devs
-
 oeps:
   oep-2: True
   oep-7: True


### PR DESCRIPTION
Remove deprecated fields from openedx.yaml, per the [OEP](https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html). The ownership document should the single source of truth for ownership information.