### PR TITLE
fix: Add proper tracking initialization and page track event calls

### DIFF
--- a/FrontendPlatformWrapper.jsx
+++ b/FrontendPlatformWrapper.jsx
@@ -9,6 +9,7 @@ import {
   getAuthenticatedHttpClient,
   ensureAuthenticatedUser,
   hydrateAuthenticatedUser,
+  getAuthenticatedUser,
 } from '@edx/frontend-platform/auth';
 import { mergeConfig, getConfig } from '@edx/frontend-platform/config';
 import {
@@ -19,6 +20,7 @@ import {
 import {
   configure as configureAnalytics,
   SegmentAnalyticsService,
+  identifyAuthenticatedUser,
 } from '@edx/frontend-platform/analytics';
 
 import {
@@ -63,6 +65,8 @@ export default ({ children }) => {
 
     ensureAuthenticatedUser().then(() => {
       hydrateAuthenticatedUser().then(() => {
+        const authUser = getAuthenticatedUser();
+        identifyAuthenticatedUser(authUser.userId);
         setReady(true);
       });
     });

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
+import { sendPageEvent } from '@edx/frontend-platform/analytics';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import SiteFooter from '@edx/frontend-component-footer-edx';
@@ -10,6 +11,10 @@ import { SiteHeader } from '../site-header';
 import './styles/Layout.scss';
 
 class Layout extends Component {
+  componentDidMount() {
+    sendPageEvent();
+  }
+
   getUserMenuItems = () => {
     const { header: { userMenu } = {} } = this.context;
     return userMenu || [];

--- a/src/components/programs-list/tests/ProgramListPage.test.jsx
+++ b/src/components/programs-list/tests/ProgramListPage.test.jsx
@@ -10,6 +10,7 @@ jest.mock('@edx/frontend-platform/auth');
 getAuthenticatedUser.mockReturnValue({
   username: 'edx',
 });
+jest.mock('@edx/frontend-platform/analytics');
 
 describe('ProgramListPage', () => {
   const pageContext = {


### PR DESCRIPTION
### Description

We can track learner portal visit data in google analytics. Currently, without this fix, we can only see click events sent. 