### PR TITLE
Feat: MICROBA-1522 Add notices redirect to learning MFE

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -16,6 +16,7 @@ HOSTNAME='example'
 UNBRANDED_LANDING_PAGE=''
 USE_PROGRAMS_MOCK_DATA=''
 IDP_SLUG='saml-default'
+ENABLE_NOTICES=''
 # uncomment the line below to use mock designer data from @edx/gatsby-source-portal-designer
 # USE_PROGRAMS_MOCK_DATA=true
 # uncomment the line below to simulate a deployment in which there is no IDP

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,6 +57,7 @@ module.exports = {
           'UNBRANDED_LANDING_PAGE',
           'IDP_SLUG',
           'ENABLE_PATH_PREFIX',
+          'ENABLE_NOTICES',
         ],
       },
     },

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { AppContext } from '@edx/frontend-platform/react';
 import SiteFooter from '@edx/frontend-component-footer-edx';
+import NoticesProvider from '../notices-provider';
 
 import { SiteHeader } from '../site-header';
 
@@ -26,21 +27,23 @@ class Layout extends Component {
     } = this.props;
     return (
       <IntlProvider locale="en">
-        <>
-          <Helmet titleTemplate="%s - edX" defaultTitle="edX">
-            <html lang="en" />
-          </Helmet>
-          <SiteHeader
-            headerLogo={headerLogo}
-            logoAltText={siteName}
-            logoDestination={siteUrl}
-            userMenu={this.getUserMenuItems()}
-          />
-          <main id="content">
-            {children}
-          </main>
-          <SiteFooter />
-        </>
+        <NoticesProvider>
+          <>
+            <Helmet titleTemplate="%s - edX" defaultTitle="edX">
+              <html lang="en" />
+            </Helmet>
+            <SiteHeader
+              headerLogo={headerLogo}
+              logoAltText={siteName}
+              logoDestination={siteUrl}
+              userMenu={this.getUserMenuItems()}
+            />
+            <main id="content">
+              {children}
+            </main>
+            <SiteFooter />
+          </>
+        </NoticesProvider>
       </IntlProvider>
     );
   }

--- a/src/components/notices-provider/NoticesProvider.jsx
+++ b/src/components/notices-provider/NoticesProvider.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { getNotices } from './api';
+/**
+ * This component uses the platform-plugin-notices plugin to function.
+ * If the user has an unacknowledged notice, they will be rerouted off
+ * programs dashboard and onto a full-screen notice page. If the plugin is not
+ * installed, or there are no notices, we just passthrough this component.
+ */
+const NoticesProvider = ({ children }) => {
+  useEffect(() => {
+    async function getData() {
+      if (process.env.ENABLE_NOTICES) {
+        const data = await getNotices();
+        if (data && data.results && data.results.length > 0) {
+          const { results } = data;
+          window.location.replace(`${results[0]}?next=${window.location.href}`);
+        }
+      }
+    }
+    getData();
+  }, []);
+
+  return (
+    <div>
+      {children}
+    </div>
+  );
+};
+
+NoticesProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default NoticesProvider;

--- a/src/components/notices-provider/api.js
+++ b/src/components/notices-provider/api.js
@@ -1,0 +1,25 @@
+/* eslint-disable import/prefer-default-export */
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
+import { logError, logInfo } from '@edx/frontend-platform/logging';
+
+export const getNotices = async () => {
+  const authenticatedUser = getAuthenticatedUser();
+  const url = new URL(`${getConfig().LMS_BASE_URL}/notices/api/v1/unacknowledged`);
+  if (authenticatedUser) {
+    try {
+      const { data } = await getAuthenticatedHttpClient().get(url.href, {});
+      return data;
+    } catch (e) {
+      // we will just swallow error, as that probably means the notices app is not installed.
+      // Notices are not necessary for the rest of dashboard to function.
+      const { customAttributes: { httpErrorStatus } } = e;
+      if (httpErrorStatus === 404) {
+        logInfo(`${e}. This probably happened because the notices plugin is not installed on platform.`);
+      } else {
+        logError(e);
+      }
+    }
+  }
+  return null;
+};

--- a/src/components/notices-provider/index.js
+++ b/src/components/notices-provider/index.js
@@ -1,0 +1,1 @@
+export { default } from './NoticesProvider';

--- a/src/components/programs-list/tests/__snapshots__/ProgramListPage.test.jsx.snap
+++ b/src/components/programs-list/tests/__snapshots__/ProgramListPage.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProgramListPage correctly renders the loading page 1`] = `
-Array [
+<div>
   <main
     id="content"
   >
@@ -23,7 +23,7 @@ Array [
         </div>
       </div>
     </div>
-  </main>,
+  </main>
   <footer
     aria-label="edX Home"
     className="footer d-flex justify-content-center border-top py-3 px-4"
@@ -414,12 +414,12 @@ Array [
         </p>
       </div>
     </div>
-  </footer>,
-]
+  </footer>
+</div>
 `;
 
 exports[`ProgramListPage renders fetching program error page when there are issues fetching the user programs 1`] = `
-Array [
+<div>
   <main
     id="content"
   >
@@ -463,7 +463,7 @@ Array [
         </div>
       </div>
     </div>
-  </main>,
+  </main>
   <footer
     aria-label="edX Home"
     className="footer d-flex justify-content-center border-top py-3 px-4"
@@ -854,6 +854,6 @@ Array [
         </p>
       </div>
     </div>
-  </footer>,
-]
+  </footer>
+</div>
 `;


### PR DESCRIPTION
To support the notices plugin on platform, this adds a redirect to the course home page. If a user lands on that page and has not acknowledged a notice, the user will be redirected to notice instead of the course home. The user can back out of the notice, or acknowledge it. They will continue to see the notice every time they hit any course until it is acknowledged.