### PR TITLE
fix: legacy view should be viewed by default

### DIFF
--- a/src/components/program/ProgramPage.jsx
+++ b/src/components/program/ProgramPage.jsx
@@ -30,7 +30,7 @@ class ProgramPage extends Component {
     super(props);
     this.state = {
       hasProgramAccess: false,
-      showLegacyView: false,
+      showLegacyView: true,
     };
   }
 


### PR DESCRIPTION
issue found during testing. if API does not return any result tab view is rendering because the legacy view is set to false as default. the legacy view is set as default to align with existing user experience.