### PR TITLE
chore: add repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,8 +79,5 @@
     "clean": "gatsby clean",
     "shell": "gatsby repl"
   },
-  "repository": {
-    "type": "git",
-    "url": ""
-  }
+  "repository": "https://github.com/edx/frontend-app-learner-portal-programs"
 }


### PR DESCRIPTION
Adds a repository URL to the package.json file so tooling such as Paragon Usage Insights can properly link to the Github repository.